### PR TITLE
Add esi-search.search_structures.v1 scope to environment.ini

### DIFF
--- a/app/Controller/Ccp/Sso.php
+++ b/app/Controller/Ccp/Sso.php
@@ -505,25 +505,31 @@ class Sso extends Api\User{
                 $characterData->corporation = null;
                 $characterData->alliance = null;
 
-                if($corporationId = (int)$characterDataBasic['corporation']['id']){
-                    /**
-                     * @var $corporation Pathfinder\CorporationModel
-                     */
-                    $corporation = Pathfinder\AbstractPathfinderModel::getNew('CorporationModel');
-                    $corporation->getById($corporationId, 0);
-                    if($corporation->valid()){
-                        $characterData->corporation = $corporation;
-                    }
-                }
+                $characterAffiliation = $this->getF3()->ccpClient()->send('getCharacterAffiliation', [$characterId]);
+                if(count($characterAffiliation) === 1) {
+                    $characterCorporationId = $characterAffiliation[0]['corporation']['id'];
+                    $characterAllianceId = $characterAffiliation[0]['alliance']['id'];
 
-                if($allianceId = (int)$characterDataBasic['alliance']['id']){
-                    /**
-                     * @var $alliance Pathfinder\AllianceModel
-                     */
-                    $alliance = Pathfinder\AbstractPathfinderModel::getNew('AllianceModel');
-                    $alliance->getById($allianceId, 0);
-                    if($alliance->valid()){
-                        $characterData->alliance = $alliance;
+                    if($corporationId = (int)$characterCorporationId){
+                        /**
+                         * @var $corporation Pathfinder\CorporationModel
+                         */
+                        $corporation = Pathfinder\AbstractPathfinderModel::getNew('CorporationModel');
+                        $corporation->getById($corporationId, 0);
+                        if($corporation->valid()){
+                            $characterData->corporation = $corporation;
+                        }
+                    }
+
+                    if($allianceId = (int)$characterAllianceId){
+                        /**
+                         * @var $alliance Pathfinder\AllianceModel
+                         */
+                        $alliance = Pathfinder\AbstractPathfinderModel::getNew('AllianceModel');
+                        $alliance->getById($allianceId, 0);
+                        if($alliance->valid()){
+                            $characterData->alliance = $alliance;
+                        }
                     }
                 }
             }

--- a/app/environment.ini
+++ b/app/environment.ini
@@ -36,7 +36,7 @@ CCP_SSO_DOWNTIME            =   11:00
 ; CCP ESI API
 CCP_ESI_URL                 =   https://esi.evetech.net
 CCP_ESI_DATASOURCE          =   singularity
-CCP_ESI_SCOPES              =   esi-location.read_online.v1,esi-location.read_location.v1,esi-location.read_ship_type.v1,esi-ui.write_waypoint.v1,esi-ui.open_window.v1,esi-universe.read_structures.v1,esi-corporations.read_corporation_membership.v1,esi-clones.read_clones.v1,esi-characters.read_corporation_roles.v1
+CCP_ESI_SCOPES              =   esi-location.read_online.v1,esi-location.read_location.v1,esi-location.read_ship_type.v1,esi-ui.write_waypoint.v1,esi-ui.open_window.v1,esi-universe.read_structures.v1,esi-corporations.read_corporation_membership.v1,esi-clones.read_clones.v1,esi-characters.read_corporation_roles.v1,esi-search.search_structures.v1
 CCP_ESI_SCOPES_ADMIN        =
 
 ; SMTP settings (optional)
@@ -90,7 +90,7 @@ CCP_SSO_DOWNTIME            =   11:00
 ; CCP ESI API
 CCP_ESI_URL                 =   https://esi.evetech.net
 CCP_ESI_DATASOURCE          =   tranquility
-CCP_ESI_SCOPES              =   esi-location.read_online.v1,esi-location.read_location.v1,esi-location.read_ship_type.v1,esi-ui.write_waypoint.v1,esi-ui.open_window.v1,esi-universe.read_structures.v1,esi-corporations.read_corporation_membership.v1,esi-clones.read_clones.v1,esi-characters.read_corporation_roles.v1
+CCP_ESI_SCOPES              =   esi-location.read_online.v1,esi-location.read_location.v1,esi-location.read_ship_type.v1,esi-ui.write_waypoint.v1,esi-ui.open_window.v1,esi-universe.read_structures.v1,esi-corporations.read_corporation_membership.v1,esi-clones.read_clones.v1,esi-characters.read_corporation_roles.v1,esi-search.search_structures.v1
 CCP_ESI_SCOPES_ADMIN        =
 
 ; SMTP settings (optional)


### PR DESCRIPTION
The codebase was updated in 2.2.1 to use the esi-search.search_structures.v1 endpoint however the default environment.ini was still missing this scope.