### PR TITLE
eve-scout: fix thera routes (#221)

### DIFF
--- a/app/Controller/Api/Rest/Route.php
+++ b/app/Controller/Api/Rest/Route.php
@@ -274,21 +274,22 @@ class Route extends AbstractRestController {
                 $enrichJumpData = function(array &$row, string $systemSourceKey, string $systemTargetKey) use (&$jumpData) {
                     // check if response data is valid
                     if(
-                        is_object($systemSource = $row[$systemSourceKey]) && !empty((array)$systemSource) &&
-                        is_object($systemTarget = $row[$systemTargetKey]) && !empty((array)$systemTarget)
+                        is_array($systemSource = $row[$systemSourceKey]) && !empty($systemSource) &&
+                        is_array($systemTarget = $row[$systemTargetKey]) && !empty($systemTarget)
                     ){
-                        if(!array_key_exists($systemSource->id, $jumpData)){
-                            $jumpData[$systemSource->id] = [
-                                'systemId'          => (int)$systemSource->id,
-                                'systemName'        => $systemSource->name,
-                                'constellationId'   => (int)$systemSource->constellationID,
-                                'regionId'          => (int)$systemSource->regionId,
-                                'trueSec'           => $systemSource->security,
+                        $srcId = $systemSource['id'];
+                        $targetId = $systemTarget['id'];
+                        if(!array_key_exists($srcId, $jumpData)){
+                            $jumpData[$srcId] = [
+                                'systemId'          => $srcId,
+                                'systemName'        => $systemSource['name'],
+                                'jumpNodes'         => [],
                             ];
                         }
 
-                        if( !in_array((int)$systemTarget->id, (array)$jumpData[$systemSource->id]['jumpNodes']) ){
-                            $jumpData[$systemSource->id]['jumpNodes'][] = (int)$systemTarget->id;
+                        $jumpNodes = $jumpData[$srcId]['jumpNodes'];
+                        if( !in_array($targetId, $jumpData[$srcId]['jumpNodes']) ){
+                            $jumpData[$srcId]['jumpNodes'][] = $targetId;
                         }
                     }
                 };


### PR DESCRIPTION
It appears the data returned from the code that mediates access to the EVE Scout Thera connections data is now returning an array instead of an object.

Update the code to retrieve the contents accordingly. Also correctly initialise the empty jump nodes list when creating a new system entry.