### PR TITLE
Add super EOL (1-hour) wormhole connection support

### DIFF
--- a/app/Controller/Api/Rest/SystemThera.php
+++ b/app/Controller/Api/Rest/SystemThera.php
@@ -92,6 +92,9 @@ class SystemThera extends AbstractRestController {
             if($wormholeData['estimatedEol'] <= 4){
                 $type[] = 'wh_eol';
             }
+            if($wormholeData['estimatedEol'] <= 1){
+                $type[] = 'wh_eol_super';
+            }
             switch($wormholeData['jumpMass']) {
                 case "capital":
                     $type[] = 'wh_jump_mass_xl';

--- a/app/Cron/MapUpdate.php
+++ b/app/Cron/MapUpdate.php
@@ -142,6 +142,58 @@ class MapUpdate extends AbstractCron {
     }
 
     /**
+     * delete expired super EOL connections
+     * >> php index.php "/cron/deleteEolSuperConnections"
+     * @param \Base $f3
+     * @throws \Exception
+     */
+    function deleteEolSuperConnections(\Base $f3){
+        $this->logStart(__FUNCTION__, false);
+        $eolSuperExpire = (int)$f3->get('PATHFINDER.CACHE.EXPIRE_CONNECTIONS_EOL_SUPER');
+
+        $total = 0;
+        $count = 0;
+        if($eolSuperExpire > 0){
+            if($pfDB = $f3->DB->getDB('PF')){
+                $sql = "SELECT
+                    `con`.`id`
+                FROM
+                  `connection` `con` INNER JOIN
+                  `map` ON
+                    `map`.`id` = `con`.`mapId`
+                WHERE
+                  `map`.`deleteEolSuperConnections` = :deleteEolSuperConnections AND
+                  TIMESTAMPDIFF(SECOND, `con`.`eolSuperUpdated`, NOW() ) > :expire_time
+            ";
+
+                $connectionsData = $pfDB->exec($sql, [
+                    'deleteEolSuperConnections' => 1,
+                    'expire_time' => $eolSuperExpire
+                ]);
+
+                if($connectionsData){
+                    $total = count($connectionsData);
+                    /**
+                     * @var $connection Pathfinder\ConnectionModel
+                     */
+                    $connection = Pathfinder\AbstractPathfinderModel::getNew('ConnectionModel');
+                    foreach($connectionsData as $data){
+                        $connection->getById( (int)$data['id'] );
+                        if($connection->valid()){
+                            $connection->erase();
+                            $count++;
+                        }
+                    }
+                }
+            }
+        }
+
+        $importCount = $total;
+
+        $this->logEnd(__FUNCTION__, $total, $count, $importCount);
+    }
+
+    /**
      * delete expired WH connections after max lifetime for wormholes is reached
      * >> php index.php "/cron/deleteExpiredConnections"
      * @param \Base $f3

--- a/app/Model/Pathfinder/ConnectionModel.php
+++ b/app/Model/Pathfinder/ConnectionModel.php
@@ -87,6 +87,10 @@ class ConnectionModel extends AbstractMapTrackingModel {
             'type' => Schema::DT_TIMESTAMP,
             'default' => null
         ],
+        'eolSuperUpdated' => [
+            'type' => Schema::DT_TIMESTAMP,
+            'default' => null
+        ],
         'signatures' => [
             'has-many' => ['Exodus4D\Pathfinder\Model\Pathfinder\SystemSignatureModel', 'connectionId']
         ],
@@ -115,6 +119,7 @@ class ConnectionModel extends AbstractMapTrackingModel {
         'wh_jump_mass_xl',
         // other types
         'wh_eol',
+        'wh_eol_super',
         'preserve_mass'
     ];
 
@@ -134,6 +139,7 @@ class ConnectionModel extends AbstractMapTrackingModel {
         $connectionData->updated        = strtotime($this->updated);
         $connectionData->created        = strtotime($this->created);
         $connectionData->eolUpdated     = strtotime($this->eolUpdated);
+        $connectionData->eolSuperUpdated = strtotime($this->eolSuperUpdated);
 
         if( !empty($endpointsData = $this->getEndpointsData()) ){
             $connectionData->endpoints = $endpointsData;
@@ -167,12 +173,33 @@ class ConnectionModel extends AbstractMapTrackingModel {
         // set EOL timestamp
         if( !in_array('wh_eol', $type) ){
             $this->eolUpdated = null;
+            // removing EOL also removes super EOL
+            $type = array_values(array_diff($type, ['wh_eol_super']));
+            $this->eolSuperUpdated = null;
         }elseif(
             in_array('wh_eol', $type) &&
             !in_array('wh_eol', (array)$this->type) // $this->type == null for new connection! (e.g. map import)
         ){
             // connection EOL status change
             $this->touch('eolUpdated');
+        }
+
+        // set super EOL timestamp
+        if( !in_array('wh_eol_super', $type) ){
+            $this->eolSuperUpdated = null;
+        }elseif(
+            in_array('wh_eol_super', $type) &&
+            !in_array('wh_eol_super', (array)$this->type)
+        ){
+            // connection super EOL status change
+            $this->touch('eolSuperUpdated');
+            // super EOL implies regular EOL
+            if( !in_array('wh_eol', $type) ){
+                $type[] = 'wh_eol';
+                if( !in_array('wh_eol', (array)$this->type) ){
+                    $this->touch('eolUpdated');
+                }
+            }
         }
 
         return $type;

--- a/app/Model/Pathfinder/ConnectionModel.php
+++ b/app/Model/Pathfinder/ConnectionModel.php
@@ -170,6 +170,22 @@ class ConnectionModel extends AbstractMapTrackingModel {
         // -> reset keys! otherwise JSON format results in object and not in array
         $type = array_values(array_intersect(array_unique((array)$type), self::$connectionTypeWhitelist));
 
+        // set super EOL timestamp (must be checked BEFORE regular EOL
+        // so that super EOL can auto-add wh_eol before the EOL block runs)
+        if( !in_array('wh_eol_super', $type) ){
+            $this->eolSuperUpdated = null;
+        }elseif(
+            in_array('wh_eol_super', $type) &&
+            !in_array('wh_eol_super', (array)$this->type)
+        ){
+            // connection super EOL status change
+            $this->touch('eolSuperUpdated');
+            // super EOL implies regular EOL
+            if( !in_array('wh_eol', $type) ){
+                $type[] = 'wh_eol';
+            }
+        }
+
         // set EOL timestamp
         if( !in_array('wh_eol', $type) ){
             $this->eolUpdated = null;
@@ -182,24 +198,6 @@ class ConnectionModel extends AbstractMapTrackingModel {
         ){
             // connection EOL status change
             $this->touch('eolUpdated');
-        }
-
-        // set super EOL timestamp
-        if( !in_array('wh_eol_super', $type) ){
-            $this->eolSuperUpdated = null;
-        }elseif(
-            in_array('wh_eol_super', $type) &&
-            !in_array('wh_eol_super', (array)$this->type)
-        ){
-            // connection super EOL status change
-            $this->touch('eolSuperUpdated');
-            // super EOL implies regular EOL
-            if( !in_array('wh_eol', $type) ){
-                $type[] = 'wh_eol';
-                if( !in_array('wh_eol', (array)$this->type) ){
-                    $this->touch('eolUpdated');
-                }
-            }
         }
 
         return $type;

--- a/app/Model/Pathfinder/MapModel.php
+++ b/app/Model/Pathfinder/MapModel.php
@@ -92,6 +92,12 @@ class MapModel extends AbstractMapTrackingModel {
             'default' => 1,
             'activity-log' => true
         ],
+        'deleteEolSuperConnections' => [
+            'type' => Schema::DT_BOOL,
+            'nullable' => false,
+            'default' => 1,
+            'activity-log' => true
+        ],
         'persistentAliases' => [
             'type' => Schema::DT_BOOL,
             'nullable' => false,
@@ -232,6 +238,7 @@ class MapModel extends AbstractMapTrackingModel {
             $mapData->icon                                  = $this->icon;
             $mapData->deleteExpiredConnections              = $this->deleteExpiredConnections;
             $mapData->deleteEolConnections                  = $this->deleteEolConnections;
+            $mapData->deleteEolSuperConnections             = $this->deleteEolSuperConnections;
             $mapData->persistentAliases                     = $this->persistentAliases;
             $mapData->persistentSignatures                  = $this->persistentSignatures;
             $mapData->trackAbyssalJumps                     = $this->trackAbyssalJumps;

--- a/app/cron.ini
+++ b/app/cron.ini
@@ -27,6 +27,9 @@ downtime        =   0 11 * * *
 ; delete EOL connections
 deleteEolConnections                =   {{ @NAMESPACE }}\Cron\MapUpdate->deleteEolConnections, @fiveMinutes
 
+; delete super EOL connections
+deleteEolSuperConnections           =   {{ @NAMESPACE }}\Cron\MapUpdate->deleteEolSuperConnections, @fiveMinutes
+
 ; delete expired wh connections
 deleteExpiredConnections            =   {{ @NAMESPACE }}\Cron\MapUpdate->deleteExpiredConnections, @hourly
 

--- a/app/pathfinder.ini
+++ b/app/pathfinder.ini
@@ -313,6 +313,12 @@ EXPIRE_MAX                  =   864000
 ; Default:  15300 (4h + 15min)
 EXPIRE_CONNECTIONS_EOL      =   15300
 
+; Expire time for Super EOL (1h end of life) connections
+;           Super EOL connections get auto deleted by cronjob afterwards.
+; Syntax:   Integer (seconds)
+; Default:  4500 (1h + 15min)
+EXPIRE_CONNECTIONS_EOL_SUPER =  4500
+
 ; Expire time for WH connections
 ;           WH connections get auto deleted by cronjob afterwards.
 ;           This can be overwritten for each map in the UI.

--- a/js/app/init.js
+++ b/js/app/init.js
@@ -380,6 +380,9 @@ define([], () => {
             wh_eol: {
                 cssClass: 'pf-map-connection-wh-eol'
             },
+            wh_eol_super: {
+                cssClass: 'pf-map-connection-wh-eol-super'
+            },
             wh_fresh: {
                 cssClass: 'pf-map-connection-wh-fresh'
             },

--- a/js/app/map/contextmenu.js
+++ b/js/app/map/contextmenu.js
@@ -103,6 +103,7 @@ define([
             id: config.connectionContextMenuId,
             items: [
                 {icon: 'fa-hourglass-end', action: 'wh_eol', text: 'toggle EOL'},
+                {icon: 'fa-hourglass-end', action: 'wh_eol_super', text: 'toggle super EOL'},
                 {icon: 'fa-exclamation-triangle', action: 'preserve_mass', text: 'preserve mass'},
                 {icon: 'fa-reply fa-rotate-180', action: 'change_status', text: 'mass status', subitems: [
                         {subIcon: 'fa-circle', subIconClass: 'txt-color txt-color-gray', subAction: 'status_fresh', subText: 'stage 1 (fresh)'},

--- a/js/app/map/map.js
+++ b/js/app/map/map.js
@@ -757,6 +757,19 @@ define([
             case 'wh_eol':          // set "end of life"
                 MapOverlayUtil.getMapOverlay(mapElement, 'timer').startMapUpdateCounter();
                 MapUtil.toggleConnectionType(connection, action);
+                // removing EOL also removes super EOL
+                if(action === 'wh_eol' && !connection.hasType('wh_eol')){
+                    MapUtil.removeConnectionTypes(connection, ['wh_eol_super']);
+                }
+                MapUtil.markAsChanged(connection);
+                break;
+            case 'wh_eol_super':    // set "super end of life"
+                MapOverlayUtil.getMapOverlay(mapElement, 'timer').startMapUpdateCounter();
+                MapUtil.toggleConnectionType(connection, action);
+                // adding super EOL also adds regular EOL
+                if(connection.hasType('wh_eol_super') && !connection.hasType('wh_eol')){
+                    MapUtil.addConnectionTypes(connection, ['wh_eol']);
+                }
                 MapUtil.markAsChanged(connection);
                 break;
             case 'status_fresh':
@@ -929,7 +942,8 @@ define([
                     connectionId:   connectionId,
                     updated:        connectionData.updated,
                     created:        connectionData.created,
-                    eolUpdated:     connectionData.eolUpdated
+                    eolUpdated:     connectionData.eolUpdated,
+                    eolSuperUpdated: connectionData.eolSuperUpdated
                 });
 
                 if(connection.scope !== map.Defaults.Scope){
@@ -1044,7 +1058,7 @@ define([
         }
 
         // check for unhandled connection type changes ----------------------------------------------------------------
-        let allToggleTypes = ['wh_eol', 'preserve_mass'];
+        let allToggleTypes = ['wh_eol', 'wh_eol_super', 'preserve_mass'];
         let newTypes = allToggleTypes.intersect(newConnectionData.type.diff(currentConnectionData.type));
         let oldTypes = allToggleTypes.intersect(currentConnectionData.type.diff(newConnectionData.type));
 
@@ -1080,6 +1094,7 @@ define([
         connection.setParameter('created', newConnectionData.created);
         connection.setParameter('updated', newConnectionData.updated);
         connection.setParameter('eolUpdated', newConnectionData.eolUpdated);
+        connection.setParameter('eolSuperUpdated', newConnectionData.eolSuperUpdated);
         connection.setParameter('changed', false);
 
         return connection;
@@ -1878,6 +1893,9 @@ define([
             // active menu actions
             if(connection.hasType('wh_eol') === true){
                 options.active.push('wh_eol');
+            }
+            if(connection.hasType('wh_eol_super') === true){
+                options.active.push('wh_eol_super');
             }
             if(connection.hasType('preserve_mass') === true){
                 options.active.push('preserve_mass');

--- a/js/app/map/overlay/overlay.js
+++ b/js/app/map/overlay/overlay.js
@@ -531,7 +531,7 @@ define([
                                 label: '<i class="fas fa-fw fa-hourglass-end"></i>&nbsp;' + Util.formatTimeParts(diff),
                                 id: MapOverlayUtil.config.connectionOverlayEolSuperId,
                                 cssClass: [MapOverlayUtil.config.componentOverlayClass, 'eol'].join(' '),
-                                location: 0.25
+                                location: 0.15
                             }
                         ]);
                     }

--- a/js/app/map/overlay/overlay.js
+++ b/js/app/map/overlay/overlay.js
@@ -508,6 +508,43 @@ define([
                     }
                 }
             }
+        },
+        connectionEolSuper: {
+            title: 'Super EOL',
+            trigger: 'hover',
+            class: 'pf-map-overlay-connection-eol-super',
+            iconClass: ['fas', 'fa-fw', 'fa-hourglass-end'],
+            hoverIntent: {
+                over: function(e){
+                    let map = getMapObjectFromOverlayIcon(this);
+                    let connections = MapUtil.searchConnectionsByScopeAndType(map, 'wh', ['wh_eol_super']);
+                    let serverDate = Util.getServerTime();
+
+                    for(let connection of connections){
+                        let eolSuperTimestamp = connection.getParameter('eolSuperUpdated');
+                        let eolSuperDate = Util.convertTimestampToServerTime(eolSuperTimestamp);
+                        let diff = Util.getTimeDiffParts(eolSuperDate, serverDate);
+
+                        connection.addOverlay([
+                            'Label',
+                            {
+                                label: '<i class="fas fa-fw fa-hourglass-end"></i>&nbsp;' + Util.formatTimeParts(diff),
+                                id: MapOverlayUtil.config.connectionOverlayEolSuperId,
+                                cssClass: [MapOverlayUtil.config.componentOverlayClass, 'eol'].join(' '),
+                                location: 0.25
+                            }
+                        ]);
+                    }
+                },
+                out: function(e){
+                    let map = getMapObjectFromOverlayIcon(this);
+                    let connections = MapUtil.searchConnectionsByScopeAndType(map, 'wh', ['wh_eol_super']);
+
+                    for(let connection of connections){
+                        connection.removeOverlay(MapOverlayUtil.config.connectionOverlayEolSuperId);
+                    }
+                }
+            }
         }
     };
 

--- a/js/app/map/overlay/util.js
+++ b/js/app/map/overlay/util.js
@@ -27,6 +27,7 @@ define([
         connectionOverlayArrowId: 'pf-map-connection-arrow-overlay',                        // connection Arrows overlay ID (jsPlumb)
         connectionOverlayWhId: 'pf-map-connection-wh-overlay',                              // connection WH overlay ID (jsPlumb)
         connectionOverlayEolId: 'pf-map-connection-eol-overlay',                            // connection EOL overlay ID (jsPlumb)
+        connectionOverlayEolSuperId: 'pf-map-connection-eol-super-overlay',              // connection super EOL overlay ID (jsPlumb)
 
         debugOverlayId: 'pf-map-debug-overlay',                                             // connection/endpoint overlay ID (jsPlumb)
 

--- a/js/app/ui/dialog/map_settings.js
+++ b/js/app/ui/dialog/map_settings.js
@@ -37,6 +37,7 @@ define([
         // settings map form
         deleteExpiredConnectionsId: 'pf-map-dialog-delete-connections-expired',         // id for "deleteExpiredConnections" checkbox
         deleteEolConnectionsId: 'pf-map-dialog-delete-connections-eol',                 // id for "deleteEOLConnections" checkbox
+        deleteEolSuperConnectionsId: 'pf-map-dialog-delete-connections-eol-super',   // id for "deleteEOLSuperConnections" checkbox
         persistentAliasesId: 'pf-map-dialog-persistent-aliases',                        // id for "persistentAliases" checkbox
         persistentSignaturesId: 'pf-map-dialog-persistent-signatures',                  // id for "persistentSignatures" checkbox
         trackAbyssalJumpsId: 'pf-map-dialog-track-abyss-jumps',                         // id for "trackAbyssalJumps" checkbox
@@ -160,6 +161,7 @@ define([
                     // settings tab --------------
                     deleteExpiredConnectionsId : config.deleteExpiredConnectionsId,
                     deleteEolConnectionsId : config.deleteEolConnectionsId,
+                    deleteEolSuperConnectionsId : config.deleteEolSuperConnectionsId,
                     persistentAliasesId : config.persistentAliasesId,
                     persistentSignaturesId : config.persistentSignaturesId,
                     trackAbyssalJumpsId : config.trackAbyssalJumpsId,
@@ -168,6 +170,7 @@ define([
 
                     deleteExpiredConnections: true,
                     deleteEolConnections: true,
+                    deleteEolSuperConnections: true,
                     persistentAliases: true,
                     persistentSignatures: true,
                     trackAbyssalJumps: false,
@@ -232,6 +235,7 @@ define([
                     Object.assign(mapDialogData, {
                         deleteExpiredConnections: mapData.config.deleteExpiredConnections,
                         deleteEolConnections: mapData.config.deleteEolConnections,
+                        deleteEolSuperConnections: mapData.config.deleteEolSuperConnections,
                         persistentAliases: mapData.config.persistentAliases,
                         persistentSignatures: mapData.config.persistentSignatures,
                         trackAbyssalJumps: mapData.config.trackAbyssalJumps,

--- a/js/app/ui/form_element.js
+++ b/js/app/ui/form_element.js
@@ -187,6 +187,9 @@ define([
                     if(type.includes('wh_eol')){
                         styleClass.push('pf-wh-eol');
                     }
+                    if(type.includes('wh_eol_super')){
+                        styleClass.push('pf-wh-eol-super');
+                    }
                     if(type.includes('wh_reduced')){
                         styleClass.push('pf-wh-reduced');
                     }

--- a/public/templates/dialog/map.html
+++ b/public/templates/dialog/map.html
@@ -74,6 +74,17 @@
 
                                 <div class="col-xs-6 col-sm-6 col-md-4">
                                     <div class="form-group">
+                                        <div class="col-xs-12 col-sm-12 checkbox" >
+                                            <input id="{{deleteEolSuperConnectionsId}}" name="deleteEolSuperConnections" value="1" type="checkbox" {{#deleteEolSuperConnections}}checked{{/deleteEolSuperConnections}}>
+                                            <label for="{{deleteEolSuperConnectionsId}}">Auto delete super expired wormholes
+                                                <i class="fas fa-fw fa-question-circle pf-help-light" title="super expired EOL WHs (~1h 15min)"></i>
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="col-xs-6 col-sm-6 col-md-4">
+                                    <div class="form-group">
                                         <div class="col-xs-12 col-sm-12 checkbox">
                                             <input id="{{persistentAliasesId}}" name="persistentAliases" value="1" type="checkbox" {{#persistentAliases}}checked{{/persistentAliases}}>
                                             <label for="{{persistentAliasesId}}">Persistent system aliases

--- a/sass/layout/_animation.scss
+++ b/sass/layout/_animation.scss
@@ -110,6 +110,19 @@
   }
 }
 
+// SVG pulse "stroke-opacity" for super EOL connections =============================================
+@include keyframes(pfPulseEol){
+  0% {
+    stroke-opacity: 1;
+  }
+  50% {
+    stroke-opacity: 0.4;
+  }
+  100% {
+    stroke-opacity: 1;
+  }
+}
+
 // pulse-out ======================================================================================
 @mixin pf-pulse-keyframes($name, $color, $backgroundColor, $keepVisible: false){
   @include keyframes($name){

--- a/sass/layout/_main.scss
+++ b/sass/layout/_main.scss
@@ -1485,6 +1485,10 @@ table{
     border-color: $pink-dark;
   }
 
+  &.pf-map-connection-wh-eol-super{
+    border-color: $red;
+  }
+
   &.pf-map-connection-wh-reduced{
     background-color: $orange;
   }
@@ -1568,6 +1572,10 @@ table{
 
   &.pf-wh-eol{
     border-color: $pink-dark;
+  }
+
+  &.pf-wh-eol-super{
+    border-color: $red;
   }
 
   &.pf-wh-reduced{

--- a/sass/layout/_map.scss
+++ b/sass/layout/_map.scss
@@ -736,7 +736,8 @@ $mapBubbleWidth:        30px;
   .pf-map-connection-wh-fresh,
   .pf-map-connection-wh-reduced,
   .pf-map-connection-wh-critical,
-  .pf-map-connection-wh-eol{
+  .pf-map-connection-wh-eol,
+  .pf-map-connection-wh-eol-super{
     z-index: 70;
   }
 
@@ -744,6 +745,18 @@ $mapBubbleWidth:        30px;
 
     path:first-child{
       stroke: $pink-dark;
+    }
+  }
+
+  // super EOL: must be AFTER .pf-map-connection-wh-eol for CSS specificity
+  .pf-map-connection-wh-eol-super {
+
+    path:first-child{
+      stroke: $red;
+      animation-name: pfPulseEol;
+      animation-duration: 1.5s;
+      animation-timing-function: ease-in-out;
+      animation-iteration-count: infinite;
     }
   }
 


### PR DESCRIPTION
## Summary

EVE Online now distinguishes two End of Life states for wormholes. This PR adds the new 1-hour "super EOL" indicator alongside the existing 4-hour EOL system.

- **New connection type** `wh_eol_super` with separate context menu toggle
- **Visual styling**: red pulsing line (distinct from pink EOL)
- **Cascade logic**: toggling super EOL auto-adds regular EOL; removing regular EOL also removes super EOL
- **Auto-delete**: separate cron job with configurable timer (default 1h 15min via `EXPIRE_CONNECTIONS_EOL_SUPER`)
- **Per-map settings**: new checkbox to enable/disable super EOL auto-deletion
- **Overlay timer**: hover shows elapsed time since super EOL was set
- **Thera integration**: auto-detects `estimatedEol <= 1` from eveScout data

### Files changed (17)

**PHP Backend**: ConnectionModel, MapModel, MapUpdate cron, cron.ini, pathfinder.ini, SystemThera, Route (no change needed)  
**JavaScript**: init.js, contextmenu.js, map.js, overlay.js, overlay/util.js, form_element.js, map_settings.js  
**Styling**: _animation.scss, _map.scss, _main.scss  
**Templates**: map.html

### Database

New columns auto-created by Fat-Free Cortex on next setup:
- `connection.eolSuperUpdated` (TIMESTAMP, nullable)
- `map.deleteEolSuperConnections` (BOOL, default 1)

## Test plan

- [ ] Right-click a wormhole connection → "toggle super EOL" appears in context menu
- [ ] Toggling super EOL ON shows red pulsing line and also activates regular EOL
- [ ] Toggling super EOL OFF reverts to pink EOL line
- [ ] Toggling regular EOL OFF removes both EOL and super EOL
- [ ] Hover super EOL overlay icon shows elapsed time on super EOL connections
- [ ] Map settings → "Auto delete super expired wormholes" checkbox appears and persists
- [ ] Cron `deleteEolSuperConnections` deletes connections after configured expiry
- [ ] Map export/import preserves super EOL state

🤖 Generated with [Claude Code](https://claude.com/claude-code)