### PR TITLE
Security: fix error-based SQL injection in Route excludeTypes (GHSA-rpv2-hpp2-9vxq)

### DIFF
--- a/app/Controller/Api/Rest/Route.php
+++ b/app/Controller/Api/Rest/Route.php
@@ -163,7 +163,10 @@ class Route extends AbstractRestController {
                 }
 
                 if(!empty($filterData['excludeTypes'])){
-                    $excludeTypes = $filterData['excludeTypes'];
+                    $excludeTypes = array_values(array_intersect(
+                        array_map('strval', (array)$filterData['excludeTypes']),
+                        Pathfinder\ConnectionModel::getConnectionTypeWhitelist()
+                    ));
                 }
             }
 

--- a/app/Controller/Controller.php
+++ b/app/Controller/Controller.php
@@ -748,11 +748,12 @@ class Controller {
                 $error = $exception->getError();
             }else{
                 // ... handle error $f3->error() calls
+                $debug = (int)$f3->get('DEBUG');
                 $error = $this->getErrorObject(
                     $errorData['code'],
                     $errorData['status'],
-                    $errorData['text'],
-                    $f3->get('DEBUG') >= 1 ? $errorData['trace'] : null
+                    $debug >= 1 ? $errorData['text'] : 'An internal error occurred',
+                    $debug >= 1 ? $errorData['trace'] : null
                 );
             }
 

--- a/app/Model/Pathfinder/ConnectionModel.php
+++ b/app/Model/Pathfinder/ConnectionModel.php
@@ -119,6 +119,13 @@ class ConnectionModel extends AbstractMapTrackingModel {
     ];
 
     /**
+     * @return string[]
+     */
+    public static function getConnectionTypeWhitelist() : array {
+        return self::$connectionTypeWhitelist;
+    }
+
+    /**
      * get connection data
      * @param bool $addSignatureData
      * @param bool $addLogData


### PR DESCRIPTION
## Summary

Backports the fix for [GHSA-rpv2-hpp2-9vxq](https://github.com/goryn-clade/pathfinder/security/advisories/GHSA-rpv2-hpp2-9vxq) from `release/v3.0` (commit `b2a14da`) to `master` (v2.2.4).

The `/api/rest/Route` endpoint concatenated user-supplied `excludeTypes` values directly into a `REGEXP` clause, enabling error-based SQL injection via `ExtractValue()` that could exfiltrate the database (including stored ESI access/refresh tokens). Verbose DB error text was also returned to clients regardless of `DEBUG` level, which is what makes error-based exfiltration practical.

## Changes

- **`Route.php`** — `excludeTypes` is now intersected against `ConnectionModel::getConnectionTypeWhitelist()` before being inlined into SQL, so only known-safe values can reach the `REGEXP` clause.
- **`ConnectionModel.php`** — exposes the existing `$connectionTypeWhitelist` via a public static accessor so `Route.php` can use the canonical list rather than duplicating it.
- **`Controller.php`** — `showError()` now replaces `ERROR.text` with a generic message when `DEBUG < 1`. Previously only the stack trace was suppressed; the raw DB error string (the channel exploited for error-based exfiltration) was returned in all modes.

## Scope

This is a minimal cherry-pick of the SQLi fix only. The wider `filterConnectionTypes()` hardening (787f0e3 in v3.0, applying the same allowlist to `includeScopes`/`includeTypes`/`excludeEndpointTypes`) is deliberately left out — those lists are not currently reachable from untrusted input on v2.2.x.

## Test plan
- [ ] Confirm `/api/rest/Route` route search still works with normal `excludeTypes` values (e.g. `wh_eol`, `wh_critical`)
- [ ] Confirm an `excludeTypes` payload containing a SQL injection probe (e.g. `extractvalue(...)`) is silently dropped from the query and the route search still returns a normal result
- [ ] Confirm a deliberate 500 (DB error or otherwise) with `DEBUG=0` returns `"An internal error occurred"` instead of the raw error text
- [ ] Confirm with `DEBUG>=1` the original error text is still returned (dev ergonomics preserved)